### PR TITLE
Add option to customize amount of views and days, only post password in payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If no password argument is given, a 20 character password comprised of letters, 
 ### Usage:
 
 ```
-usage: pwpush [-h] [-u URL] [-p PASSWORD]
+usage: pwpush [-h] [-u URL] [-p PASSWORD] [-d DAYS] [-v VIEWS]
 
 Accept a password from stdin.
 
@@ -15,6 +15,9 @@ optional arguments:
   -u URL, --url URL     Optional: Specify the URL of a local pwpush instance. ex: pwpush -u https://foobar.com
   -p PASSWORD, --password PASSWORD
                         Optional: User defined password.
+  -d DAYS, --days DAYS  Optional: Specify the amount of days after which the password should expire.
+  -v VIEWS, --views VIEWS
+                        Optional: Specify the amount of views after which the password should expire.
 ```
 
 ex.
@@ -23,7 +26,7 @@ ex.
 Pass is: GKtPq:@%Q'r2Jakf7RQ0
 URL: https://pwpush.com/p/tkfrluql1hi0f6qt
 
-> ./pwpush -p foobar -u http://localhost:5100`
+> ./pwpush -p foobar -u http://localhost:5100 -v 5
 Pass is: foobar
 URL: http://localhost:5100/p/630thim25imnm2x1
 ```

--- a/pwpush
+++ b/pwpush
@@ -31,12 +31,16 @@ parser.add_argument('-u', '--url', type=str,
         help="Optional: Specify the URL of a local pwpush instance. ex: pwpush -u https://foobar.com", default="https://pwpush.com")
 parser.add_argument('-p', '--password', type=str,
         help="Optional: User defined password.", default=autogen_pw())
+parser.add_argument('-d', '--days', type=int,
+        help="Optional: Specify the amount of days after which the password should expire.", default=2)
+parser.add_argument('-v', '--views', type=int,
+        help="Optional: Specify the amount of views after which the password should expire.", default=10)
 args = parser.parse_args()
 
 payload = {
-    'password[payload]': args,
-    'password[expire_after_days]': '2',
-    'password[expire_after_views]': '10'
+    'password[payload]': args.password,
+    'password[expire_after_days]': args.days,
+    'password[expire_after_views]': args.views
 }
 r = requests.post(f"{args.url}/p.json", data=payload)
 r_response = json.loads(r.content)['url_token']


### PR DESCRIPTION
Hi! Thanks for #2.

After using the utility I wanted the possibility to modify the amount of days or views before the password expires. When adding that functionality I noticed that the payload actually posts `args` which causes the uploaded password to look something like: `Namespace(url='https://pw.radivoj.se', password='@\\;9D*PwQe;"aOf$=&[')`

![Capture](https://user-images.githubusercontent.com/26885267/137119165-824ee889-04ec-4b75-9ddc-16132d554306.PNG)
