### PR TITLE
feat: add `length` argument for password autogen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@ If no password argument is given, a 20 character password comprised of letters, 
 ### Usage:
 
 ```
-usage: pwpush [-h] [-u URL] [-p PASSWORD] [-d DAYS] [-v VIEWS]
+usage: pwpush [-h] [-u URL] [-p PASSWORD] [-l LENGTH] [-d DAYS] [-v VIEWS]
 
 Accept a password from stdin.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -u URL, --url URL     Optional: Specify the URL of a local pwpush instance. ex: pwpush -u https://foobar.com
   -p PASSWORD, --password PASSWORD
                         Optional: User defined password.
+  -l LENGTH, --length LENGTH
+                        Optional: Length of auto-generated password. Ignored if password argument already provided.
   -d DAYS, --days DAYS  Optional: Specify the amount of days after which the password should expire.
   -v VIEWS, --views VIEWS
                         Optional: Specify the amount of views after which the password should expire.
@@ -29,4 +31,13 @@ URL: https://pwpush.com/p/tkfrluql1hi0f6qt
 > ./pwpush -p foobar -u http://localhost:5100 -v 5
 Pass is: foobar
 URL: http://localhost:5100/p/630thim25imnm2x1
+
+# -l is ignored since -p takes precedence
+> ./pwpush -l 10 -p africanswallow
+Pass is: africanswallow
+URL: https://pwpush.com/p/zynqhemqkyvxi4q
+
+> ./pwpush -l 10
+Pass is: 0ezR.)cwg,
+URL: https://pwpush.com/p/9ylhw57z4_qywugmqw
 ```

--- a/pwpush
+++ b/pwpush
@@ -19,10 +19,10 @@ import string
 import json
 
 
-def autogen_pw():
+def autogen_pw(length):
     alphabet = string.ascii_letters + string.digits + string.punctuation
     password = ''.join(secrets.choice(alphabet)
-                       for i in range(20))  # for a 20-character password
+                       for _ in range(length))
     return password
 
 
@@ -30,15 +30,19 @@ parser = argparse.ArgumentParser(description='Accept a password from stdin.')
 parser.add_argument('-u', '--url', type=str,
         help="Optional: Specify the URL of a local pwpush instance. ex: pwpush -u https://foobar.com", default="https://pwpush.com")
 parser.add_argument('-p', '--password', type=str,
-        help="Optional: User defined password.", default=autogen_pw())
+        help="Optional: User defined password.")
+parser.add_argument('-l', '--length', type=int, default=20,
+        help="Optional: Length of auto-generated password. Ignored if password argument already provided.")
 parser.add_argument('-d', '--days', type=int,
         help="Optional: Specify the amount of days after which the password should expire.", default=2)
 parser.add_argument('-v', '--views', type=int,
         help="Optional: Specify the amount of views after which the password should expire.", default=10)
 args = parser.parse_args()
 
+password = args.password or autogen_pw(args.length)
+
 payload = {
-    'password[payload]': args.password,
+    'password[payload]': password,
     'password[expire_after_days]': args.days,
     'password[expire_after_views]': args.views
 }
@@ -46,5 +50,5 @@ r = requests.post(f"{args.url}/p.json", data=payload)
 r_response = json.loads(r.content)['url_token']
 
 # Console output
-print(f'Pass is: {args.password}')
+print(f'Pass is: {password}')
 print(f'URL: {args.url}/p/{r_response}')


### PR DESCRIPTION
Adds `-l | --length` argument.

Exceprts from the updated README:
```
  -l LENGTH, --length LENGTH
                        Optional: Length of auto-generated password. Ignored if password argument already provided.
```

ex.
```
# -l is ignored since -p takes precedence
> ./pwpush -l 10 -p africanswallow
Pass is: africanswallow
URL: https://pwpush.com/p/zynqhemqkyvxi4q

> ./pwpush -l 10
Pass is: 0ezR.)cwg,
URL: https://pwpush.com/p/9ylhw57z4_qywugmqw
```